### PR TITLE
[WIP] Change from Route 53 to Google Cloud DNS

### DIFF
--- a/source/diagrams/10-1-network.mmd
+++ b/source/diagrams/10-1-network.mmd
@@ -15,7 +15,9 @@ graph LR
   end
   subgraph AWS US East/West
     cloudfront["AWS CloudFront"]
-    route53["AWS Route 53"]
+  end
+  subgraph Google Cloud Platform
+    gcpdns["Google Cloud DNS"]
   end
   subgraph AWS GovCloud
     apps-elb["Customer ELB"]
@@ -82,7 +84,7 @@ graph LR
   customer(("Customer"))
   ops(("Cloud Operations"))
 
-  customer-.DNS.->route53
+  customer-.DNS.->gcpdns
   customer--Web-->cloudfront
   customer--Web or CLI-->apps-elb
   customer-->statuspage


### PR DESCRIPTION
This change captures how we'll adjust the diagrams when we cease using Route 53 and start using Google Cloud DNS. 

DO NOT MERGE THIS PR UNTIL THE SCR IS APPROVED BY FEDRAMP AND THE DNS CHANGE IS COMPLETE.