### PR TITLE
Revert "Bump mermaid from 6.0.0 to 8.7.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp": "^3.9.1",
     "gulp-sass": "^2.3.2",
     "gulp-util": "^3.0.7",
-    "mermaid": "^8.7.0",
+    "mermaid": "^6.0.0",
     "mustache": "^2.2.1",
     "node-notifier": "^4.6.0",
     "node-sass": "^3.8.0",


### PR DESCRIPTION
Mermaid 8.7.0 requires a newer version of Node, which requires a lot of
other work

This reverts commit d7e2ce220a6d45e6385a451664d38e5a48729faa.

## Changes proposed in this pull request:
- go back to mermaid 6.0

## security considerations
the mermaid bump was to work around a vulnerability in mermaid - we still need to do this bump, it'll just take more work