### PR TITLE
Update `save-svg-as-png` to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-notifier": "^8.0.1",
     "node-sass": "^4.14.1",
     "plugin-error": "^1.0.1",
-    "save-svg-as-png": "git://github.com/exupero/saveSvgAsPng#f56023b",
+    "save-svg-as-png": "^1.4.17",
     "serve-static": "^1.11.1",
     "through2": "^2.0.1",
     "uswds": "^2.8.1",


### PR DESCRIPTION
Update `save-svg-as-png` dependency to fix pipeline failures

## Changes proposed in this pull request:

- Update `package.json` to install `save-svg-as-png` from npm package instead of directly from Github to fix pipeline failures

## security considerations

None
