### PR TITLE
remove stack from manifest to allow move to cflinuxfs4

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,6 @@ applications:
   disk_quota: 1024M
   routes:
   - route: diagrams.fr.cloud.gov
-  buildpacks: 
+  buildpacks:
   - staticfile_buildpack
-  stack: cflinuxfs3
   path: public


### PR DESCRIPTION
## Changes proposed in this pull request:

-remove stack from manifest to allow move to cflinuxfs4

## security considerations

None
