### PR TITLE
CSSS-44 update monitoring diagram

### DIFF
--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -13,7 +13,7 @@ graph LR
     subgraph Cloud Foundry Components
       boshdirector{"BOSH Director"}
       firehose{"Metrics"}
-      concourse{"Concourse<br>CI/CD Pipelines"}
+      concourse{"Concourse<br>(CI/CD Pipelines)"}
     end
     subgraph Centralized Monitoring Components
       nessus["Nessus Manager"]
@@ -28,6 +28,7 @@ graph LR
       snort{"Snort IDS<br>(Intrusion Detection)"}
       boshagent["BOSH Agent"]
       node-exporter["Prometheus Node Exporter"]
+      aide["AIDE<br>(Filesystem Integrity)"]
     end
 
   end
@@ -67,7 +68,7 @@ graph LR
 
   clamav-updates--Security Definition Updates-->clamav
   clamav--Sends Alerts-->prometheus
-  
+  aide--Sends Alerts-->logs
   logs--Sends Logs-->prometheus
 
   snort-updates--Security Definition Updates-->snort

--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -19,6 +19,7 @@ graph LR
       nessus["Nessus Manager"]
       prometheus["Prometheus Alerting/Storage"]
       grafana["Grafana<br>(Time Series Visualizations)"]
+      doomsday["Doomsday<br>(Certificate Monitoring)"]
     end
     subgraph All EC2 Instances
       nessusagent{"Nessus<br>Scanning<br>Agent"}
@@ -30,11 +31,9 @@ graph LR
       node-exporter["Prometheus Node Exporter"]
       aide["AIDE<br>(Filesystem Integrity)"]
     end
-
   end
   subgraph GSA Responsibility
     SAML{"Single Sign-on (SSO)<br>providing MFA"}
-    gsanessus>"GSA Nessus Manager (Tenable Security Center)"]
   end
   subgraph External
     statuspage["StatusPage"]
@@ -51,9 +50,7 @@ graph LR
 
   nessusagent--Sends Scanning Results-->nessus
   nessus--Monitors-->nessusagent
-  gsanessus--Sends Settings Updates-->nessus
-  nessus--Sends Scanning Results-->gsanessus
-  nessus--Reports-->email
+  nessus--Reports SMTP 587-->email
   tenable-updates--Security Definition Updates-->nessus
 
   node-exporter--System Performance Metrics-->prometheus
@@ -63,8 +60,8 @@ graph LR
 
   logs--Sends Logs-->aws-logs-agent
   logs--Sends Performance Metrics-->aws-cloudwatch
-  aws-logs-agent--Sends Encrypted Log Data Only-->aws-logs
-  aws-logs--View Logs-->aws-console
+  aws-logs-agent--Sends Log Data-->aws-logs
+  aws-console--View Logs-->aws-logs
 
   clamav-updates--Security Definition Updates-->clamav
   clamav--Sends Alerts-->prometheus
@@ -76,20 +73,24 @@ graph LR
 
   prometheus--Visualizes events-->grafana
   alb-->grafana
-  prometheus--Processes alerts-->Googlegroups
+  alb-->doomsday
+  prometheus--Processes alerts SMTP 587-->Googlegroups
   Googlegroups-->email
 
   UAA-.Authentication.->SAML
   grafana-.Authorization.->UAA
+  doomsday-.Authorization.->UAA
 
   aws-console-."Authentication/Authorization".->aws-iam
   statuspage-."Authentication/Authorization".->sp-account
   email-->Ops
-  Ops--HTTPS-->zscaler--HTTPS-->alb
-  Ops--HTTPS-->aws-console
-  Ops--HTTPS-->Googlegroups
+  Ops--HTTPS 443-->zscaler
+  zscaler--HTTPS 443-->alb
+  Ops--HTTPS 443-->aws-console
+  Ops--HTTPS 443-->Googlegroups
 
-  aws-guardduty--Findings-->Googlegroups
-  aws-cloudwatch-alarms--Alarm Notifications-->Googlegroups
-  aws-cloudwatch-alarms--AWS Login Failure Alerts-->slack
-  concourse--Pipeline Status-->slack
+  aws-guardduty--Findings SMTP 587-->Googlegroups
+  aws-cloudwatch-alarms--Alarm Notifications SMTP 587-->Googlegroups
+  aws-cloudwatch-alarms--AWS Login Failure Alerts HTTPS 443-->slack
+  concourse--Pipeline Status HTTPS 443-->slack
+  doomsday--Expiration Warnings HTTPS 443-->slack

--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -7,11 +7,13 @@ graph LR
     aws-logs["AWS CloudWatch Logs"]
     aws-cloudwatch["AWS CloudWatch"]
     aws-console["AWS Console"]
-    aws-api["AWS API"]
     aws-iam("AWS IAM")
+    aws-guardduty["AWS GuardDuty"]
+    aws-cloudwatch-alarms["AWS Cloudwatch Alarms"]
     subgraph Cloud Foundry Components
       boshdirector{"BOSH Director"}
       firehose{"Metrics"}
+      concourse{"Concourse<br>CI/CD Pipelines"}
     end
     subgraph Centralized Monitoring Components
       nessus["Nessus Manager"]
@@ -40,9 +42,11 @@ graph LR
     Googlegroups["Google Groups"]
     snort-updates>"Snort Network<br>Vulnerability Profiles"]
     tenable-updates>"Tenable Updates"]
+    slack["GSA Slack"]
   end
   email("Email")
   Ops((Cloud Operations))
+  zscaler("Zscaler VPN")
 
   nessusagent--Sends Scanning Results-->nessus
   nessus--Monitors-->nessusagent
@@ -55,7 +59,6 @@ graph LR
   firehose-->prometheus
   boshagent-->boshdirector
   boshdirector--Health Monitor state changes-->prometheus
-  boshdirector--AWS Metrics-->prometheus
 
   logs--Sends Logs-->aws-logs-agent
   logs--Sends Performance Metrics-->aws-cloudwatch
@@ -81,6 +84,11 @@ graph LR
   aws-console-."Authentication/Authorization".->aws-iam
   statuspage-."Authentication/Authorization".->sp-account
   email-->Ops
-  Ops--HTTPS-->alb
+  Ops--HTTPS-->zscaler--HTTPS-->alb
   Ops--HTTPS-->aws-console
   Ops--HTTPS-->Googlegroups
+
+  aws-guardduty--Findings-->Googlegroups
+  aws-cloudwatch-alarms--Alarm Notifications-->Googlegroups
+  aws-cloudwatch-alarms--AWS Login Failure Alerts-->slack
+  concourse--Pipeline Status-->slack

--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -1,17 +1,18 @@
 %% title: 10-4.3 Monitoring & Alerting Data Flow
 %% description: Section 10 - System Environment - Figure 10-4.3 Monitoring & Alerting Data Flow
 graph LR
-  subgraph AWS US West Oregon
-    kinesis["AWS Kinesis"]
-  end
   subgraph AWS GovCloud
-    elb["AWS Elastic Load Balancer<br>(ELB)"]
+    alb["AWS Application Load Balancer<br>(ALB)"]
     UAA["User Authentication/Authorization (UAA)"]
     aws-logs["AWS CloudWatch Logs"]
     aws-cloudwatch["AWS CloudWatch"]
     aws-console["AWS Console"]
     aws-api["AWS API"]
     aws-iam("AWS IAM")
+    subgraph Cloud Foundry Components
+      boshdirector{"BOSH Director"}
+      firehose{"Metrics"}
+    end
     subgraph Centralized Monitoring Components
       nessus["Nessus Manager"]
       prometheus["Prometheus Alerting/Storage"]
@@ -20,18 +21,13 @@ graph LR
     subgraph All EC2 Instances
       nessusagent{"Nessus<br>Scanning<br>Agent"}
       clamav{"ClamAV<br>(Virus/Malware)"}
-      tripwire{"Tripwire<br>(Filesystem Integrity)"}
       logs("System Logs")
       aws-logs-agent{"AWS<br>CloudWatch<br>Logs Agent"}
-      nragent{"New Relic Agent"}
       snort{"Snort IDS<br>(Intrusion Detection)"}
       boshagent["BOSH Agent"]
       node-exporter["Prometheus Node Exporter"]
     end
-    subgraph Cloud Foundry Components
-      boshdirector{"BOSH Director"}
-      firehose{"Metrics"}
-    end
+
   end
   subgraph GSA Responsibility
     SAML{"Single Sign-on (SSO)<br>providing MFA"}
@@ -57,16 +53,13 @@ graph LR
 
   node-exporter--System Performance Metrics-->prometheus
   firehose-->prometheus
-  aws-api--AWS Metrics-->boshdirector
   boshagent-->boshdirector
   boshdirector--Health Monitor state changes-->prometheus
   boshdirector--AWS Metrics-->prometheus
 
-  tripwire--Sends Report-->logs
   logs--Sends Logs-->aws-logs-agent
   logs--Sends Performance Metrics-->aws-cloudwatch
-  aws-logs-agent--Sends Encrypted Log Data Only-->kinesis
-  kinesis--Sends Encrypted Log Data Only-->aws-logs
+  aws-logs-agent--Sends Encrypted Log Data Only-->aws-logs
   aws-logs--View Logs-->aws-console
 
   clamav-updates--Security Definition Updates-->clamav
@@ -78,8 +71,8 @@ graph LR
   snort--Sends Alerts-->prometheus
 
   prometheus--Visualizes events-->grafana
-  elb-->grafana
-  prometheus--Processes alerts-->googlegroups
+  alb-->grafana
+  prometheus--Processes alerts-->Googlegroups
   Googlegroups-->email
 
   UAA-.Authentication.->SAML
@@ -88,6 +81,6 @@ graph LR
   aws-console-."Authentication/Authorization".->aws-iam
   statuspage-."Authentication/Authorization".->sp-account
   email-->Ops
-  Ops--HTTPS-->elb
+  Ops--HTTPS-->alb
   Ops--HTTPS-->aws-console
-  Ops--HTTPS-->googlegroups
+  Ops--HTTPS-->Googlegroups

--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -16,17 +16,17 @@ graph LR
       concourse{"Concourse<br>(CI/CD Pipelines)"}
     end
     subgraph Centralized Monitoring Components
-      nessus["Nessus Manager"]
-      prometheus["Prometheus Alerting/Storage"]
-      grafana["Grafana<br>(Time Series Visualizations)"]
-      doomsday["Doomsday<br>(Certificate Monitoring)"]
+      nessus{"Nessus Manager"}
+      prometheus{"Prometheus<br>Alerting/Storage"}
+      grafana{"Grafana<br>(Time Series Visualizations)"}
+      doomsday{"Doomsday<br>(Certificate Monitoring)"}
     end
     subgraph All EC2 Instances
-      nessusagent{"Nessus<br>Scanning<br>Agent"}
-      clamav{"ClamAV<br>(Virus/Malware)"}
-      logs("System Logs")
-      aws-logs-agent{"AWS<br>CloudWatch<br>Logs Agent"}
-      snort{"Snort IDS<br>(Intrusion Detection)"}
+      nessusagent["Nessus<br>Scanning<br>Agent"]
+      clamav["ClamAV<br>(Virus/Malware)"]
+      logs["System Logs"]
+      aws-logs-agent["AWS<br>CloudWatch<br>Logs Agent"]
+      snort["Snort IDS<br>(Intrusion Detection)"]
       boshagent["BOSH Agent"]
       node-exporter["Prometheus Node Exporter"]
       aide["AIDE<br>(Filesystem Integrity)"]
@@ -65,7 +65,7 @@ graph LR
 
   clamav-updates--Security Definition Updates-->clamav
   clamav--Sends Alerts-->prometheus
-  aide--Sends Alerts-->logs
+  aide--Sends Alerts-->prometheus
   logs--Sends Logs-->prometheus
 
   snort-updates--Security Definition Updates-->snort


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removed Tripwire and New Relic agent
- Removed Kinesis and GSA Nessus
- Added AIDE where Tripwire was
- Added Zscaler
- Added Doomsday
- Changed ELB term to ALB
- Consolidated to a single instance of Googlegroups
- Added Slack, Guardduty, Cloudwatch Alarms
- Added ports for most connections
- Updated some item visuals to better match the legend

## security considerations
This diagram is referenced in the SSP and part of the accreditation package.
